### PR TITLE
URL Cleanup

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -10,11 +10,11 @@
 
     <p>
       There are a few tools for building <a
-      href="http://java.sun.com/j2se/javadoc/">javadoc</a>-like
+      href="https://java.sun.com/j2se/javadoc/">javadoc</a>-like
       documentation for .NET code available out there on the
       'net. Unfortunately, the major contenders (e.g. <a
       href="http://ndoc.sourceforge.net/">NDoc</a>, <a
-      href="http://www.sandcastledocs.com/">Sandcastle</a>) suffer
+      href="https://www.sandcastledocs.com/">Sandcastle</a>) suffer
       from a few flaws: they are variously not free (gratis), not free
       (libre), not cross-platform, not maintained, and/or not
       easy-to-use.
@@ -36,9 +36,9 @@
       </li>
       <li>
 	Uses Microsoft's XML documentation comments (see <a
-	href="http://msdn.microsoft.com/msdnmag/issues/02/06/XMLC/">here</a>
+	href="https://msdn.microsoft.com/msdnmag/issues/02/06/XMLC/">here</a>
 	and <a
-	href="http://msdn2.microsoft.com/EN-US/library/b2s063f7(VS.80).aspx">here</a>)
+	href="https://msdn.microsoft.com/EN-US/library/b2s063f7(VS.80).aspx">here</a>)
       </li>
       <li>Runs on Mono as well as Microsoft's .NET</li>
     </ul>
@@ -60,21 +60,21 @@
 
     <p>
       NDocProc is available as a <a
-      href="http://www.selenic.com/mercurial/">mercurial</a>
+      href="https://www.selenic.com/mercurial/">mercurial</a>
       repository:
     </p>
 
     <pre>
-      hg clone http://hg.opensource.lshift.net/ndocproc
+      hg clone https://bitbucket.org/lshift/ndocproc
     </pre>
 
     <p>
       Occasional source/binary snapshots are made, and are usually
       found buried somewhere on <a
-      href="http://www.lshift.net/~tonyg/">this page</a> (look for
+      href="https://tech.labs.oliverwyman.com/~tonyg/">this page</a> (look for
       <code>ndocproc-YYYYMMDDHHMM.zip</code>). Periodic
       NDocProc-related announcements will be made on the <a
-      href="http://www.lshift.net/blog/category/lshift-sw/">"our
+      href="https://tech.labs.oliverwyman.com/blog/category/lshift-sw/">"our
       software" category of LShift's blog</a>.
     </p>
 
@@ -158,8 +158,8 @@ THE SOFTWARE.
 
     <ul>
       <li>
-	<a href="http://www.mono-project.com/">Mono</a>, or Microsoft
-	<a href="http://msdn2.microsoft.com/en-us/netframework/default.aspx">.NET SDK</a>
+	<a href="https://www.mono-project.com/">Mono</a>, or Microsoft
+	<a href="https://msdn.microsoft.com/en-us/netframework/default.aspx">.NET SDK</a>
       </li>
       <li><a href="http://nant.sourceforge.net/">NAnt</a> 0.85</li>
     </ul>

--- a/xsl/utils.xsl
+++ b/xsl/utils.xsl
@@ -252,7 +252,7 @@ THE SOFTWARE.
           <xsl:choose>
 	    <xsl:when test="$googleNonlocalTypes = 'true'">
 	      <code>
-		<a class="nonlocalTypeLink" title="{$name}" href="http://www.google.com/search?q={$queryparam}&amp;btnI=I'm Feeling Lucky">
+		<a class="nonlocalTypeLink" title="{$name}" href="https://www.google.com/search?q={$queryparam}&amp;btnI=I'm Feeling Lucky">
 		  <xsl:call-template name="type-alias-impl">
 		    <xsl:with-param name="name" select="$name"/>
 		    <xsl:with-param name="leaf" select="$leaf"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://nant.sourceforge.net/ (200) with 2 occurrences could not be migrated:  
   ([https](https://nant.sourceforge.net/) result AnnotatedConnectException).
* http://ndoc.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://ndoc.sourceforge.net/) result AnnotatedConnectException).
* http://schemas.microsoft.com/developer/msbuild/2003 (404) with 1 occurrences could not be migrated:  
   ([https](https://schemas.microsoft.com/developer/msbuild/2003) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.sandcastledocs.com/ (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.sandcastledocs.com/ ([https](https://www.sandcastledocs.com/) result SSLHandshakeException).
* http://msdn.microsoft.com/msdnmag/issues/02/06/XMLC/ (301) with 1 occurrences migrated to:  
  https://msdn.microsoft.com/msdnmag/issues/02/06/XMLC/ ([https](https://msdn.microsoft.com/msdnmag/issues/02/06/XMLC/) result 404).
* http://www.lshift.net/blog/category/lshift-sw/ (301) with 1 occurrences migrated to:  
  https://tech.labs.oliverwyman.com/blog/category/lshift-sw/ ([https](https://www.lshift.net/blog/category/lshift-sw/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://hg.opensource.lshift.net/ndocproc (301) with 1 occurrences migrated to:  
  https://bitbucket.org/lshift/ndocproc ([https](https://hg.opensource.lshift.net/ndocproc) result 200).
* http://www.mono-project.com/ with 1 occurrences migrated to:  
  https://www.mono-project.com/ ([https](https://www.mono-project.com/) result 200).
* http://msdn2.microsoft.com/EN-US/library/b2s063f7 (301) with 1 occurrences migrated to:  
  https://msdn.microsoft.com/EN-US/library/b2s063f7 ([https](https://msdn2.microsoft.com/EN-US/library/b2s063f7) result 301).
* http://msdn2.microsoft.com/en-us/netframework/default.aspx (301) with 1 occurrences migrated to:  
  https://msdn.microsoft.com/en-us/netframework/default.aspx ([https](https://msdn2.microsoft.com/en-us/netframework/default.aspx) result 301).
* http://www.lshift.net/~tonyg/ (301) with 1 occurrences migrated to:  
  https://tech.labs.oliverwyman.com/~tonyg/ ([https](https://www.lshift.net/~tonyg/) result 301).
* http://java.sun.com/j2se/javadoc/ with 1 occurrences migrated to:  
  https://java.sun.com/j2se/javadoc/ ([https](https://java.sun.com/j2se/javadoc/) result 302).
* http://www.google.com/search?q= with 1 occurrences migrated to:  
  https://www.google.com/search?q= ([https](https://www.google.com/search?q=) result 302).
* http://www.selenic.com/mercurial/ with 1 occurrences migrated to:  
  https://www.selenic.com/mercurial/ ([https](https://www.selenic.com/mercurial/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/1999/XSL/Transform with 4 occurrences